### PR TITLE
vm: upgrade tooling

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,13 +65,14 @@ tasks:
     - vagrant ssh-config > ssh.config.vagrant
     # For some reason, vagrant adds "LogLevel FATAL" to the generated file.
     # We want the default logging level instead.
-    - sed -i "" 's/LogLevel FATAL//' ssh.config.vagrant
+    - sed -i.bak 's/LogLevel FATAL//' ssh.config.vagrant
+    - rm ssh.config.vagrant.bak
     # Mark this VM as a target for destructive tests.
     - ssh -F ssh.config.vagrant florist-dev sudo mkdir -p /opt/florist/disposable
     # Provision the VM with the "dev" bouquet.
     - ssh -F ssh.config.vagrant florist-dev sudo "./florist/bin/linux/dev install"
     # Install other deps. I am unsure this is the best approach...
-    - ssh -F ssh.config.vagrant florist-dev "GOBIN=/usr/local/bin sudo --preserve-env=GOBIN task -d florist install-deps"
+    - ssh -F ssh.config.vagrant florist-dev "GOBIN=/usr/local/bin sudo --preserve-env=GOBIN task -d florist install:deps"
       # Take snapshot, name `pristine`
     - vagrant snapshot save pristine
     - vagrant halt

--- a/florist/roles/dev/main.go
+++ b/florist/roles/dev/main.go
@@ -41,14 +41,14 @@ func setup(prov *florist.Provisioner) error {
 		},
 		&task.Flower{
 			Inst: task.Inst{
-				Version: "3.21.0",
-				Hash:    "7232508b0040398b3dcce5d92dfe05f65723680eab2017f3cee6c0a7cf9dd6c1",
+				Version: "3.44.0",
+				Hash:    "d6c9c0a14793659766ee0c06f9843452942ae6982a3151c6bbd78959c1682b82",
 			},
 		},
 		&golang.Flower{
 			Inst: golang.Inst{
-				Version: "1.22.0",
-				Hash:    "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",
+				Version: "1.24.4",
+				Hash:    "77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717",
 			},
 		},
 		&fishshell.Flower{


### PR DESCRIPTION
vm: upgrade tooling

- `go.mod` says: go 1.24 so we need to reflect this inthe  development VM
- task target `install-deps` doesn't exist.. it was renamed to `install:deps`
- while at it install newest task