### PR TITLE
florist:netstat: add InstanceIP function.

### DIFF
--- a/pkg/florist/netstat.go
+++ b/pkg/florist/netstat.go
@@ -113,3 +113,28 @@ func PublicIPs() ([]string, error) {
 
 	return ips, nil
 }
+
+// PrivateIP returns the first matching IP that belongs to the given network CIDR.
+func PrivateIP(cidr string) (string, error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("network CIDR: %s: error: %s", cidr, err)
+	}
+
+	ips, err := PrivateIPs()
+	if err != nil {
+		return "", err
+	}
+
+	for _, addr := range ips {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+
+		if network.Contains(ip) {
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("none of the private IPs belongs to %s network", cidr)
+}

--- a/pkg/florist/netstat_test.go
+++ b/pkg/florist/netstat_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package florist
+
+import (
+	"testing"
+
+	"github.com/marco-m/rosina/assert"
+)
+
+func TestPrivateIpSuccess(t *testing.T) {
+	have, err := PrivateIP("127.0.0.0/30")
+	assert.NoError(t, err, "florist.InstanceIP")
+	assert.Equal(t, have, "127.0.0.1", "florist.InstanceIP")
+}
+
+func TestPrivateIpFailure(t *testing.T) {
+	type testCase struct {
+		name        string
+		networkCIDR string
+		wantErr     string
+	}
+
+	test := func(t *testing.T, tc testCase) {
+		_, err := PrivateIP(tc.networkCIDR)
+		assert.ErrorContains(t, err, tc.wantErr)
+	}
+
+	testCases := []testCase{
+		{
+			name:        "invalid network CIDR",
+			networkCIDR: "123.15.12.12/128",
+			wantErr:     "invalid CIDR address",
+		},
+		{
+			name:        "no match found",
+			networkCIDR: "192.0.1.0/30",
+			wantErr:     "none of the private IPs belongs to 192.0.1.0/30 network",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) { test(t, tc) })
+	}
+}


### PR DESCRIPTION
florist:netstat: add PrivateIP function

- PrivateIP returns a first matching IP that belong to the given network CIDR..