### PR TITLE
CI: run destructive tests in VM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,10 +30,6 @@ task:
   modules_cache:
     fingerprint_script: cat go.sum
     folder: $GOPATH/pkg/mod
-  # explore_script: |
-  #   ps aux
-  #   systemctl status
-  #   exit 1
   install_go_script: |
     curl --location --fail-with-body --no-progress-meter https://go.dev/dl/${GO_PKG} -o ${GO_PKG}
     rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_PKG}
@@ -46,7 +42,8 @@ task:
     go install gotest.tools/gotestsum@latest
     curl --location --fail-with-body --no-progress-meter https://github.com/go-task/task/releases/download/${TASKFILE_VERSION}/task_linux_amd64.tar.gz -o task_linux_amd64.tar.gz
     tar xzf task_linux_amd64.tar.gz
-    ./task check-coverage
+    # The passed COVERAGE is the one from destructive tests.
+    ./task check-coverage COVERAGE='28.6%'
   lint_script: |
     go install honnef.co/go/tools/cmd/staticcheck@latest
     go vet ./...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,16 +1,50 @@
+env:
+  HOME: /root
+  # GOPATH is per-user. Here we run as root, so we put it in the root home directory.
+  GOPATH: ${HOME}/go
+  PATH: /usr/local/go/bin:${GOPATH}/bin:${PATH}
+  #
+  GO_PKG: go1.24.5.linux-amd64.tar.gz
+  TASKFILE_VERSION: v3.44.0
+
 task:
-  container:
-    image: golang:latest
-    # https://cirrus-ci.org/guide/linux/#kvm-enabled-privileged-containers
-    # kvm: true
+  # https://cirrus-ci.org/guide/custom-vms/
+  # Cirrus CI uses Google Cloud Platform for running all instances, except macos_instance.
+  # Things like Docker Builder and freebsd_instance are syntactic sugar for launching
+  # Compute Engine instances from a particular set of images.
+  # With compute_engine_instance it is possible to use any publicly available image for
+  # running your Cirrus tasks in.
+  #
+  # List all the public images of a given "project":
+  # gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images
+  #
+  compute_engine_instance:
+    image_project: cirrus-images # Name of the Cirrus CI public GCP project.
+    image: family/docker-kvm
+    platform: linux
+    # architecture: arm64
+    architecture: amd64
+    cpu: 4
+    memory: 16G
+    #nested_virtualization: true
   modules_cache:
     fingerprint_script: cat go.sum
     folder: $GOPATH/pkg/mod
-  get_script: go get ./...
+  # explore_script: |
+  #   ps aux
+  #   systemctl status
+  #   exit 1
+  install_go_script: |
+    curl --location --fail-with-body --no-progress-meter https://go.dev/dl/${GO_PKG} -o ${GO_PKG}
+    rm -rf /usr/local/go && tar -C /usr/local -xzf ${GO_PKG}
+  get_go_deps_script: go get ./...
   build_script: go build -v ./...
   test_script: |
+    #env | sort
+    # YEAH Enable Florist destructive tests!
+    mkdir -p /opt/florist/disposable
     go install gotest.tools/gotestsum@latest
-    curl --location --fail-with-body --no-progress-meter https://github.com/go-task/task/releases/download/v3.44.0/task_linux_amd64.tar.gz -o task_linux_amd64.tar.gz
+    curl --location --fail-with-body --no-progress-meter https://github.com/go-task/task/releases/download/${TASKFILE_VERSION}/task_linux_amd64.tar.gz -o task_linux_amd64.tar.gz
     tar xzf task_linux_amd64.tar.gz
     ./task check-coverage
   lint_script: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🌼 florist 🌺
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/marco-m/florist.svg)](https://pkg.go.dev/github.com/marco-m/florist)
+[![Build Status](https://api.cirrus-ci.com/github/marco-m/florist.svg?branch=master)](https://cirrus-ci.com/github/marco-m/florist)
+
 A bare-bones and opinionated Go module to create a **non-idempotent**, **one-file-contains-everything** provisioner (install and configure).
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ As such, you don't want to run the installer on your development machine. Same r
 
 The convention taken by the tests to reduce the possibility of an error is the following.
 
-When preparing the VM, target `vm:init` will create directory `opt/florist/disposable`; its presence means that the machine can be subjected to destructive tests.
+When preparing the VM, target `vm:init` will create directory `/opt/florist/disposable`; its presence means that the machine can be subjected to destructive tests.
 
 Tests that exercise a destructive functionality begin with
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,17 +35,20 @@ tasks:
 
   check-coverage:
     vars:
-      COVERAGE:
+      # This coverage is for non-destructive tests (host NOT disposable).
+      COVERAGE_MAP:
         map:
           darwin: '23.7%'
           linux: '24.0%'
+      # Can be set from command-line, see usage in .cirrus.yml
+      COVERAGE: '{{default (index .COVERAGE_MAP OS) .COVERAGE}}'
     cmds:
       - go clean -testcache
       - task: test
       - cmd: |
           have=$(go tool cover -func ./bin/coverage.out | grep ^total: | awk '{print $3}')
-          if [ $have != {{index .COVERAGE OS}} ]; then
-            echo "Coverage changed: have: $have; want: {{index .COVERAGE OS}}"
+          if [ $have != {{.COVERAGE}} ]; then
+            echo "Coverage changed: have: $have; want: {{.COVERAGE}}"
             exit 1
           else
             echo "Coverage: $have"


### PR DESCRIPTION
Cirrus CI allows to choose whether to run in a container or in a VM.
Thus we run in a VM so that we can also run the destructive tests (setting `/opt/florist/disposable`).

Thanks Cirrus CI !