### PR TITLE
Fix florist.CmdRun not collecting correctly the subprocess stdout and stderr

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,14 +36,17 @@ task:
   get_go_deps_script: go get ./...
   build_script: go build -v ./...
   test_script: |
+    export FLORIST_MANUAL_TEST=ssh
     #env | sort
     # YEAH Enable Florist destructive tests!
     mkdir -p /opt/florist/disposable
     go install gotest.tools/gotestsum@latest
     curl --location --fail-with-body --no-progress-meter https://github.com/go-task/task/releases/download/${TASKFILE_VERSION}/task_linux_amd64.tar.gz -o task_linux_amd64.tar.gz
     tar xzf task_linux_amd64.tar.gz
-    # The passed COVERAGE is the one from destructive tests.
-    ./task check-coverage COVERAGE='28.6%'
+    ./task test
+  check_coverage_script: |
+    # The passed COVERAGE value is the one from destructive tests.
+    ./task check-coverage COVERAGE='30.6%'
   lint_script: |
     go install honnef.co/go/tools/cmd/staticcheck@latest
     go vet ./...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
       # This coverage is for non-destructive tests (host NOT disposable).
       COVERAGE_MAP:
         map:
-          darwin: '23.7%'
+          darwin: '24.3%'
           linux: '24.0%'
       # Can be set from command-line, see usage in .cirrus.yml
       COVERAGE: '{{default (index .COVERAGE_MAP OS) .COVERAGE}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,18 +33,30 @@ tasks:
       - go vet ./...
       - staticcheck ./...
 
+  test:
+    desc: Run all the unit tests; makes sense only if invoking from the VM.
+    cmds:
+      - mkdir -p ./bin
+      # - go clean -testcache
+      - gotestsum -- -count=1 -coverprofile=./bin/coverage.out ./...
+
+  test:all:vm:clean:
+    desc: Run all the tests on a VM from a clean snapshot
+    cmds:
+      - task: _vm:restore
+      - task: test:all:vm:dirty
+
   check-coverage:
+    desc: 'Usage: task test check-coverage'
     vars:
       # This coverage is for non-destructive tests (host NOT disposable).
       COVERAGE_MAP:
         map:
-          darwin: '24.3%'
+          darwin: '24.7%'
           linux: '24.0%'
       # Can be set from command-line, see usage in .cirrus.yml
       COVERAGE: '{{default (index .COVERAGE_MAP OS) .COVERAGE}}'
     cmds:
-      - go clean -testcache
-      - task: test
       - cmd: |
           have=$(go tool cover -func ./bin/coverage.out | grep ^total: | awk '{print $3}')
           if [ $have != {{.COVERAGE}} ]; then
@@ -54,18 +66,6 @@ tasks:
             echo "Coverage: $have"
           fi
         silent: true
-
-  test:
-    desc: Run all the unit tests; makes sense only if invoking from the VM.
-    cmds:
-      - mkdir -p ./bin
-      - gotestsum -- -count=1 -coverprofile=./bin/coverage.out ./...
-
-  test:all:vm:clean:
-    desc: Run all the tests on a VM from a clean snapshot
-    cmds:
-      - task: _vm:restore
-      - task: test:all:vm:dirty
 
   test:all:vm:dirty:
     desc: |

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/google/go-cmp v0.7.0
 	github.com/marco-m/clim v0.1.3
-	github.com/marco-m/rosina v0.1.2
+	github.com/marco-m/rosina v0.1.3-0.20250716212657-a5b85114fbd0
 )
 
 retract (

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/marco-m/clim v0.1.3 h1:azfkyT4tSQKG226zQDFdh0WKJH9IFvPPrnUf7m5UW/0=
 github.com/marco-m/clim v0.1.3/go.mod h1:F/4eMh/Mtn/asmuM8h/qnV3BNjcrGTuJitWBVs4c5Ws=
-github.com/marco-m/rosina v0.1.2 h1:d98MrqL3qXuufOSpEyQoxzHB+Bu/ZJdrAwXgokALp8Y=
-github.com/marco-m/rosina v0.1.2/go.mod h1:XnMWRFIR8GztNE0mRL7b3B+E6r7cL5bpq48TRmtDmjw=
+github.com/marco-m/rosina v0.1.3-0.20250716212657-a5b85114fbd0 h1:VGqQQ5Ixm5OOSGXJO9ZxBVP8DN2kXjoOBEAA5UvO5kQ=
+github.com/marco-m/rosina v0.1.3-0.20250716212657-a5b85114fbd0/go.mod h1:XnMWRFIR8GztNE0mRL7b3B+E6r7cL5bpq48TRmtDmjw=

--- a/internal/testutils.go
+++ b/internal/testutils.go
@@ -1,0 +1,11 @@
+package internal
+
+import "log/slog"
+
+// RemoveTime removes the "time" attribute from the output of a slog.Logger.
+func RemoveTime(groups []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return a
+}

--- a/pkg/florist/exec.go
+++ b/pkg/florist/exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"sync"
 )
 
 // CmdRun runs 'cmd', redirecting its stdout and stderr to 'log.Debug'.
@@ -22,35 +23,51 @@ func CmdRun(log *slog.Logger, cmd *exec.Cmd) error {
 		return err
 	}
 
+	var wg sync.WaitGroup
+
+	// Collect stdout
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		outScanner := bufio.NewScanner(stdout)
+		for outScanner.Scan() {
+			line := outScanner.Text()
+			if line != "" {
+				log.Debug("cmd-run", "stdout", truncate(line, truncLen))
+			}
+		}
+		if err := outScanner.Err(); err != nil {
+			log.Debug("cmd-run: error reading stdout", "error", err)
+		}
+	}()
+
+	// Collect stderr
+	wg.Add(1)
+	var errLines []string
+	go func() {
+		defer wg.Done()
+		errScanner := bufio.NewScanner(stderr)
+		for errScanner.Scan() {
+			line := errScanner.Text()
+			if line != "" {
+				line = truncate(line, truncLen)
+				errLines = append(errLines, line)
+				log.Debug("cmd-run", "stderr", line)
+			}
+		}
+		if err := errScanner.Err(); err != nil {
+			log.Debug("cmd-run: error reading stderr", "error", err)
+		}
+	}()
+
 	if err := cmd.Start(); err != nil {
 		return err
 	}
 
-	outScanner := bufio.NewScanner(stdout)
-	for outScanner.Scan() {
-		line := outScanner.Text()
-		if line != "" {
-			log.Debug("cmd-run", "stdout", truncate(line, truncLen))
-		}
-	}
-	if err := outScanner.Err(); err != nil {
-		return err
-	}
+	// Wait for the pipes to return EOF.
+	wg.Wait()
 
-	var errLines []string
-	errScanner := bufio.NewScanner(stderr)
-	for errScanner.Scan() {
-		line := errScanner.Text()
-		if line != "" {
-			line = truncate(line, truncLen)
-			errLines = append(errLines, line)
-			log.Debug("cmd-run", "stderr", line)
-		}
-	}
-	if err := errScanner.Err(); err != nil {
-		return err
-	}
-
+	// It is now safe to call cmd.Wait, which will close the pipes.
 	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf("%s: %s", err, errLines)
 	}

--- a/pkg/florist/exec_test.go
+++ b/pkg/florist/exec_test.go
@@ -2,11 +2,14 @@ package florist_test
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
 
+	"github.com/marco-m/florist/internal"
 	"github.com/marco-m/florist/pkg/florist"
 	"github.com/marco-m/rosina/diff"
 )
@@ -15,7 +18,7 @@ func TestCmdRunBasicSuccess(t *testing.T) {
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
 		Level:       slog.LevelDebug,
-		ReplaceAttr: RemoveTime,
+		ReplaceAttr: internal.RemoveTime,
 	}))
 
 	err := florist.CmdRun(log, exec.Command("true"))
@@ -32,7 +35,7 @@ func TestCmdRunBasicFailure(t *testing.T) {
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
 		Level:       slog.LevelDebug,
-		ReplaceAttr: RemoveTime,
+		ReplaceAttr: internal.RemoveTime,
 	}))
 
 	err := florist.CmdRun(log, exec.Command("false"))
@@ -46,10 +49,75 @@ func TestCmdRunBasicFailure(t *testing.T) {
 	}
 }
 
-// RemoveTime removes the "time" attribute from the output of a slog.Logger.
-func RemoveTime(groups []string, a slog.Attr) slog.Attr {
-	if a.Key == slog.TimeKey {
-		return slog.Attr{}
+// This is part of the TestHelperProcess pattern.
+// https://web.archive.org/web/20250204012613/https://npf.io/2015/06/testing-exec-command/
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		// Avoid diagnostic printed by "go test" to stderr:
+		//   warning: GOCOVERDIR not set, no coverage data emitted
+		"GOCOVERDIR=" + os.TempDir(),
 	}
-	return a
+	return cmd
+}
+
+// This is part of the TestHelperProcess pattern.
+// https://web.archive.org/web/20250204012613/https://npf.io/2015/06/testing-exec-command/
+func TestHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	// optional: validation logic
+
+	// Simulate a process, run by florist.CmdRun(), that writes to stdout and stderr.
+	fmt.Fprintf(os.Stdout, "line 1 to stdout\n")
+	fmt.Fprintf(os.Stderr, "line 2 to stderr\n")
+	fmt.Fprintf(os.Stdout, "line 3 to stdout\n")
+	fmt.Fprintf(os.Stderr, "line 4 to stderr\n")
+	fmt.Fprintf(os.Stdout, "line 5 to stdout\n")
+	fmt.Fprintf(os.Stderr, "line 6 to stderr\n")
+
+	os.Exit(0)
+}
+
+func TestCmdRunProcWritesToStdoutAndStderr(t *testing.T) {
+	// execCommandFn = fakeExecCommand
+	// defer func() { execCommandFn = exec.Command }()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: internal.RemoveTime,
+	}))
+
+	err := florist.CmdRun(log, fakeExecCommand("anything-goes-this-is-a-fake"))
+	if err != nil {
+		t.Errorf("\nhave error: %s\nwant: <no error>", err)
+	}
+
+	// Remove the first line from buffer, because it contains the path to the Go test
+	// executable, which is in a temporary directory. For example:
+	// level=DEBUG msg=cmd-run
+	//   cmd="/var/folders/h2/sz12x.../T/go-build37.../b001/florist.test
+	//   -test.run=TestHelperProcess -- anything-goes-this-is-a-fake"
+	have := buf.String()
+	have = have[strings.Index(have, "\n"):]
+
+	// NOTE the ordering is wrong: first all writes to stdout, then all writes to stderr.
+	// This shows that the implementation is wrong.
+	want := `
+level=DEBUG msg=cmd-run stdout="line 1 to stdout"
+level=DEBUG msg=cmd-run stdout="line 3 to stdout"
+level=DEBUG msg=cmd-run stdout="line 5 to stdout"
+level=DEBUG msg=cmd-run stderr="line 2 to stderr"
+level=DEBUG msg=cmd-run stderr="line 4 to stderr"
+level=DEBUG msg=cmd-run stderr="line 6 to stderr"
+`
+	if text := diff.TextDiff("want", "have", want, have); text != "" {
+		t.Errorf("\nlog mismatch:\n%s", text)
+	}
 }

--- a/pkg/florist/exec_test.go
+++ b/pkg/florist/exec_test.go
@@ -1,22 +1,55 @@
 package florist_test
 
 import (
+	"bytes"
 	"log/slog"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/marco-m/florist/pkg/florist"
-	"github.com/marco-m/rosina/assert"
+	"github.com/marco-m/rosina/diff"
 )
 
-func TestCmdRunSuccess(t *testing.T) {
-	discard := slog.New(slog.DiscardHandler)
-	err := florist.CmdRun(discard, exec.Command("true"))
-	assert.NoError(t, err, "florist.CmdRun")
+func TestCmdRunBasicSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: RemoveTime,
+	}))
+
+	err := florist.CmdRun(log, exec.Command("true"))
+	if err != nil {
+		t.Errorf("\nhave error: %s\nwant: <no error>", err)
+	}
+	want := "level=DEBUG msg=cmd-run cmd=/usr/bin/true\n"
+	if text := diff.TextDiff("want", "have", want, buf.String()); text != "" {
+		t.Errorf("\nlog mismatch:\n%s", text)
+	}
 }
 
-func TestCmdRunFailure(t *testing.T) {
-	discard := slog.New(slog.DiscardHandler)
-	err := florist.CmdRun(discard, exec.Command("false"))
-	assert.ErrorContains(t, err, "exit status 1:")
+func TestCmdRunBasicFailure(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: RemoveTime,
+	}))
+
+	err := florist.CmdRun(log, exec.Command("false"))
+	have, needle := err.Error(), "exit status 1:"
+	if !strings.Contains(have, needle) {
+		t.Errorf("\nerror message:    %s\ndoes not contain: %s", have, needle)
+	}
+	want := "level=DEBUG msg=cmd-run cmd=/usr/bin/false\n"
+	if text := diff.TextDiff("want", "have", want, buf.String()); text != "" {
+		t.Errorf("\nlog mismatch:\n%s", text)
+	}
+}
+
+// RemoveTime removes the "time" attribute from the output of a slog.Logger.
+func RemoveTime(groups []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return a
 }


### PR DESCRIPTION
I did this change to fix #7, but now I realize that it is not enough :-(
I think that "docker compose pull" prints to stdout OR stderr a lot of characters (and control characters) WITHOUT a newline. I think that it is the missing newline that is problematic, because the scanner is waiting for a newline!
Instead it should wait for a newline OR a fixed number of characters, and log a line on the first of the two occurrences...
