### PR TITLE
florist.CmdRun: split subprocess output according to max line lenght

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,10 +44,11 @@ task:
     curl --location --fail-with-body --no-progress-meter https://github.com/go-task/task/releases/download/${TASKFILE_VERSION}/task_linux_amd64.tar.gz -o task_linux_amd64.tar.gz
     tar xzf task_linux_amd64.tar.gz
     ./task test
-  check_coverage_script: |
-    # The passed COVERAGE value is the one from destructive tests.
-    ./task check-coverage COVERAGE='30.6%'
   lint_script: |
     go install honnef.co/go/tools/cmd/staticcheck@latest
     go vet ./...
     staticcheck ./...
+  # Leave this step at the end of the task.
+  check_coverage_script: |
+    # The passed COVERAGE value is the one from destructive tests.
+    ./task check-coverage COVERAGE='31.1%'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,7 +52,7 @@ tasks:
       # This coverage is for non-destructive tests (host NOT disposable).
       COVERAGE_MAP:
         map:
-          darwin: '24.7%'
+          darwin: '25.3%'
           linux: '24.0%'
       # Can be set from command-line, see usage in .cirrus.yml
       COVERAGE: '{{default (index .COVERAGE_MAP OS) .COVERAGE}}'


### PR DESCRIPTION
This has the following advantages:

1. It permits to see output generated by tools such as "docker compose pull" that implement a spinner by using control characters and never printing a newline. This fixes marco-m/florist/issues/7.
2. Removes the panic from bufio.Splitter if it keeps going and doesn't find a newline.
3. Before it was truncating the output at 160 bytes. Now no truncation happens, the output is instead split on multiple lines.