### PR TITLE
BREAK UserAdd() and friends, take 3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,4 +51,4 @@ task:
   # Leave this step at the end of the task.
   check_coverage_script: |
     # The passed COVERAGE value is the one from destructive tests.
-    ./task check-coverage COVERAGE='33.6%'
+    ./task check-coverage COVERAGE='34.0%'

--- a/flowers/consul/consul.go
+++ b/flowers/consul/consul.go
@@ -23,7 +23,10 @@ const (
 // CommonInstall performs the install steps common to the client and the server.
 func CommonInstall(log *slog.Logger, version string, hash string) error {
 	log.Info("Add system user", "user", Username)
-	if err := florist.UserSystemAdd(Username, HomeDir); err != nil {
+	if err := florist.UserAdd(Username, florist.UserAddOpts{
+		System:  true,
+		HomeDir: HomeDir,
+	}); err != nil {
 		return err
 	}
 
@@ -32,7 +35,7 @@ func CommonInstall(log *slog.Logger, version string, hash string) error {
 	}
 
 	log.Info("Create cfg dir", "dst", CfgDir)
-	if err := os.MkdirAll(CfgDir, 0755); err != nil {
+	if err := os.MkdirAll(CfgDir, 0o755); err != nil {
 		return err
 	}
 
@@ -60,7 +63,7 @@ func installConsulExe(log *slog.Logger, version string, hash string) error {
 
 	exeDst := path.Join(BinDir, "consul")
 	log.Info("Install consul executable", "dst", exeDst)
-	if err := florist.CopyFile(extracted, exeDst, 0755, "root"); err != nil {
+	if err := florist.CopyFile(extracted, exeDst, 0o755, "root"); err != nil {
 		return err
 	}
 

--- a/flowers/consultemplate/consultemplate.go
+++ b/flowers/consultemplate/consultemplate.go
@@ -83,7 +83,10 @@ func (fl *Flower) Install() error {
 	log := slog.With("flower", Name+".install")
 
 	log.Info("Add system user 'consul-template'")
-	if err := florist.UserSystemAdd("consul-template", HomeDir); err != nil {
+	if err := florist.UserAdd("consul-template", florist.UserAddOpts{
+		System:  true,
+		HomeDir: HomeDir,
+	}); err != nil {
 		return fmt.Errorf("%s: %s", Name, err)
 	}
 

--- a/flowers/docker/docker.go
+++ b/flowers/docker/docker.go
@@ -121,7 +121,9 @@ func (fl *Flower) Install() error {
 
 	for _, username := range fl.Users {
 		log.Info("adding user to 'docker' supplementary group", "user", username)
-		if err := florist.SupplementaryGroups(username, "docker"); err != nil {
+		if err := florist.UserMod(username, florist.UserModOpts{
+			Groups: []string{"docker"},
+		}); err != nil {
 			return fmt.Errorf("%s: %s", fl, err)
 		}
 	}

--- a/pkg/florist/florist.go
+++ b/pkg/florist/florist.go
@@ -42,6 +42,12 @@ func SkipIfNotDisposableHost(t *testing.T) {
 	}
 }
 
+// Ptr returns a pointer to 'p'.
+// Needed to fill a struct field when the Go zero value cannot be used.
+func Ptr[T any](p T) *T {
+	return &p
+}
+
 func makeErrorf(prefix string) func(format string, a ...any) error {
 	return func(format string, a ...any) error {
 		return fmt.Errorf(prefix+": "+format, a...)

--- a/pkg/florist/os.go
+++ b/pkg/florist/os.go
@@ -39,9 +39,9 @@ func ListFs(fsys fs.FS) []string {
 	return files
 }
 
-// Return true if file 'fpath' exists.
+// FileExists returns true if file 'fpath' exists.
 // WARNING Checking for file existence is racy and in certain cases can lead
-// to security vulnerabilities. Think twice before using this. In the majority
+// to security vulnerabilities (TOCTOU). Think twice before using this. In the majority
 // of cases, you can simply skip the existence check, since the next operation
 // will fail in any case if the file doesn't exist.
 //

--- a/pkg/florist/user.go
+++ b/pkg/florist/user.go
@@ -3,16 +3,29 @@ package florist
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"os/user"
+	"strconv"
 	"strings"
 )
 
-// Add user and create home directory.
-// Do nothing if user already present.
-// Password login is disabled (use SSH public key or use passwd)
-func UserAdd(username string) error {
+// UserAddOpts contains the options to be passed to [UserAdd].
+type UserAddOpts struct {
+	// Create a system account. Default: create a user account.
+	System bool
+	// The home directory. Default: /home/<username>
+	HomeDir string
+	// A list of supplementary groups to which the user will be added.
+	// The default is for the user to belong only to the initial group.
+	Groups []string
+	// The UID. Default: choosen by the system. Use [Ptr] to fill it.
+	UID *int
+}
+
+// UserAdd adds user 'username' and creates its home directory.
+// It is not an error if the user is already present.
+// Password login is disabled (use SSH public key or use passwd to set).
+func UserAdd(username string, opts UserAddOpts) error {
 	log := slog.With("user", username)
 
 	log.Info("user-add")
@@ -20,20 +33,36 @@ func UserAdd(username string) error {
 		log.Debug("user-add", "status", "user-already-present")
 		return nil
 	}
-	// Here we should check for the specific user.UnknownUserError
+	// Here we should check for the specific error user.UnknownUserError
 	// but we err on optimist and keep going; in any case adduser will fail
 	// if something is wrong...
 
-	cmd := exec.Command(
-		"adduser",
-		"--gecos", fmt.Sprintf(`"user %s"`, username),
-		"--disabled-password",
-		username)
+	args := []string{
+		username,
+		fmt.Sprintf("--comment='user %s'", username),
+		"--create-home",
+	}
+	// Options:
+	if opts.System {
+		args = append(args, "--system")
+	}
+	if opts.HomeDir != "" {
+		args = append(args, "--home-dir="+opts.HomeDir)
+	}
+	if len(opts.Groups) > 0 {
+		args = append(args, "--groups="+strings.Join(opts.Groups, ","))
+	}
+	if opts.UID != nil {
+		args = append(args, "--uid="+strconv.Itoa(*opts.UID))
+	}
+
+	cmd := exec.Command("useradd", args...)
 	if err := CmdRun(log, cmd); err != nil {
-		return fmt.Errorf("user: add: %s", err)
+		return fmt.Errorf("UserAdd: %s (%s)", err, cmd)
 	}
 	log.Debug("user-add", "status", "user-added")
 
+	// Should be impossible to fail, but you never know.
 	_, err := user.Lookup(username)
 	if err != nil {
 		return fmt.Errorf("user: lookup: %s", err)
@@ -42,75 +71,50 @@ func UserAdd(username string) error {
 	return nil
 }
 
-// SupplementaryGroups adds 'username' to the supplementary groups 'groups'.
-// It is an error if any of 'groups' does not exist (create them beforehand
-// with GroupSystemAdd).
-func SupplementaryGroups(username string, groups ...string) error {
-	log := slog.With("user", username).With("groups", groups)
-
-	if len(groups) == 0 {
-		return fmt.Errorf("supplementary-groups: must specify at least one group (user: %s)",
-			username)
-	}
-	if _, err := user.Lookup(username); err != nil {
-		return fmt.Errorf("supplementary-groups: user not found (user: %s, groups: %s)",
-			username, groups)
-	}
-
-	args := strings.Join(groups, ",")
-	cmd := exec.Command("usermod", "--append", "--groups", args, username)
-	if err := CmdRun(log, cmd); err != nil {
-		return fmt.Errorf("user: add to groups: %s (user: %s, groups: %s)",
-			err, username, groups)
-	}
-	log.Debug("supplementary-groups", "status", "user-added-to-groups")
-
-	return nil
+// UserModOpts contains the options to be passed to [UserMod].
+type UserModOpts struct {
+	// A list of supplementary groups to which the user will be added.
+	Groups []string
 }
 
-// UserSystemAdd adds the system user 'username' and group 'username', with
-// home directory 'homedir' and mode 0o755.
-func UserSystemAdd(username string, homedir string) error {
+// UserMod modifies 'username' according to 'opts'.
+func UserMod(username string, opts UserModOpts) error {
 	log := slog.With("user", username)
 
-	if _, err := user.Lookup(username); err == nil {
-		log.Debug("user-system-add", "status", "user already present")
-		return nil
+	args := []string{username}
+	// Options:
+	if len(opts.Groups) > 0 {
+		args = append(args, "--groups="+strings.Join(opts.Groups, ","))
 	}
 
-	cmd := exec.Command(
-		"adduser",
-		"--system", "--group",
-		"--home", homedir,
-		"--gecos", fmt.Sprintf(`"user %s"`, username),
-		username)
+	cmd := exec.Command("usermod", args...)
 	if err := CmdRun(log, cmd); err != nil {
-		return fmt.Errorf("user: add: %s", err)
+		return fmt.Errorf("usermod: %s", err)
 	}
-	log.Debug("user-system-add", "status", "user added")
-
-	newUser, err := user.Lookup(username)
-	if err != nil {
-		return fmt.Errorf("user: lookup: %s", err)
-	}
-
-	if newUser.HomeDir != homedir {
-		return fmt.Errorf("user %s: homedir: have: %s, want: %s",
-			username, newUser.HomeDir, homedir)
-	}
-	if err := os.Chmod(newUser.HomeDir, 0o755); err != nil {
-		return fmt.Errorf("user %s: %s", username, err)
-	}
+	log.Debug("user-mod", "status", "user-modified")
 
 	return nil
 }
 
-// GroupSystemAdd adds group 'groupname'. It is not an error if 'groupname'
-// already exists.
-func GroupSystemAdd(groupname string) error {
-	log := slog.With("group", groupname)
+// GroupAddOpts contains the options to be passed to [GroupAdd].
+type GroupAddOpts struct {
+	// Create a system group. Default: create a user group.
+	System bool
+}
 
-	cmd := exec.Command("addgroup", "--system", groupname)
+// GroupAdd adds group 'groupname'.
+// It is not an error if 'groupname' already exists.
+func GroupAdd(groupname string, opts GroupAddOpts) error {
+	log := slog.With("group", groupname)
+	log.Info("group-add")
+
+	args := []string{groupname}
+	// Options:
+	if opts.System {
+		args = append(args, "--system")
+	}
+
+	cmd := exec.Command("groupadd", args...)
 	if err := CmdRun(log, cmd); err != nil {
 		return fmt.Errorf("group: add: %s", err)
 	}

--- a/pkg/florist/user_test.go
+++ b/pkg/florist/user_test.go
@@ -1,6 +1,10 @@
 package florist_test
 
 import (
+	"fmt"
+	"math/rand/v2"
+	"path"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -10,31 +14,94 @@ import (
 func TestUserAddSuccess(t *testing.T) {
 	florist.SkipIfNotDisposableHost(t)
 
-	err := florist.UserAdd("beppe")
+	// Ensure user doesn't exist.
+	name := "florist-" + strconv.Itoa(rand.IntN(100_000)+200_000)
+
+	err1 := florist.UserAdd(name, florist.UserAddOpts{})
+	if err1 != nil {
+		t.Errorf("\nadding non-existing user:\nhave error: %s\nwant: <no error>", err1)
+	}
+
+	// Now the user is already present, this should not be an error.
+	err2 := florist.UserAdd(name, florist.UserAddOpts{})
+	if err2 != nil {
+		t.Errorf("\nadding existing user:\nhave error: %s\nwant: <no error>", err1)
+	}
+
+	// The home directory has been created.
+	homeDir := path.Join("/home", name)
+	exists, err := florist.FileExists(homeDir)
+	if !exists {
+		t.Error("home directory does not exist:", homeDir)
+	}
+	if err != nil {
+		t.Errorf("\nwhile checking for existence of %s: %s", homeDir, err)
+	}
+}
+
+func TestUserAddSystemSuccess(t *testing.T) {
+	florist.SkipIfNotDisposableHost(t)
+
+	// Ensure user doesn't exist.
+	name := "florist-" + strconv.Itoa(rand.IntN(100_000)+200_000)
+	homeDir := path.Join("/opt", name)
+
+	err := florist.UserAdd(name, florist.UserAddOpts{
+		System:  true,
+		HomeDir: homeDir,
+	})
+	if err != nil {
+		t.Errorf("\nhave error: %s\nwant: <no error>", err)
+	}
+
+	// The home directory has been created.
+	exists, err := florist.FileExists(homeDir)
+	if !exists {
+		t.Error("home directory does not exist:", homeDir)
+	}
+	if err != nil {
+		t.Errorf("\nwhile checking for existence of %s: %s", homeDir, err)
+	}
+}
+
+func TestUserAddWithSupplementaryGroupsSuccess(t *testing.T) {
+	florist.SkipIfNotDisposableHost(t)
+
+	// Ensure user doesn't exist.
+	name := "florist-" + strconv.Itoa(rand.IntN(100_000)+200_000)
+
+	group := "banana"
+	err := florist.GroupAdd(group, florist.GroupAddOpts{})
+	if err != nil {
+		t.Errorf("\nhave error: %s\nwant: <no error>", err)
+	}
+
+	err = florist.UserAdd(name, florist.UserAddOpts{
+		Groups: []string{group},
+	})
 	if err != nil {
 		t.Errorf("\nhave error: %s\nwant: <no error>", err)
 	}
 }
 
-func TestSupplementaryGroupsFailure(t *testing.T) {
+func TestUserAddWithSupplementaryGroupsFailure(t *testing.T) {
 	florist.SkipIfNotDisposableHost(t)
 
-	err := florist.SupplementaryGroups("beppe", "banana")
+	// Ensure user doesn't exist.
+	name := "florist-" + strconv.Itoa(rand.IntN(100_000)+200_000)
+
+	// Ensure group doesn't exist.
+	group := "group-" + strconv.Itoa(rand.IntN(100_000)+200_000)
+
+	err := florist.UserAdd(name, florist.UserAddOpts{
+		Groups: []string{group},
+	})
 	if err == nil {
 		t.Fatalf("\nhave: <no error>\nwant: non-nil error")
 	}
 	have := err.Error()
-	needle := "group 'banana' does not exist"
+	needle := fmt.Sprintf("group '%s' does not exist", group)
 	if !strings.Contains(have, needle) {
 		t.Errorf("\nerror message:    %s\ndoes not contain: %s", have, needle)
-	}
-}
-
-func TestUserSystemAddSuccess(t *testing.T) {
-	florist.SkipIfNotDisposableHost(t)
-
-	err := florist.UserSystemAdd("maniglia", "/opt/maniglia")
-	if err != nil {
-		t.Errorf("\nhave error: %s\nwant: <no error>", err)
 	}
 }

--- a/pkg/florist/user_test.go
+++ b/pkg/florist/user_test.go
@@ -1,32 +1,40 @@
 package florist_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/marco-m/florist/pkg/florist"
-	"github.com/marco-m/rosina/assert"
 )
 
-func TestUserAddSuccessVM(t *testing.T) {
+func TestUserAddSuccess(t *testing.T) {
 	florist.SkipIfNotDisposableHost(t)
 
 	err := florist.UserAdd("beppe")
-
-	assert.NoError(t, err, "florist.UserAdd")
+	if err != nil {
+		t.Errorf("\nhave error: %s\nwant: <no error>", err)
+	}
 }
 
-func TestSupplementaryGroupsFailureVM(t *testing.T) {
+func TestSupplementaryGroupsFailure(t *testing.T) {
 	florist.SkipIfNotDisposableHost(t)
 
 	err := florist.SupplementaryGroups("beppe", "banana")
-
-	assert.ErrorContains(t, err, "group 'banana' does not exist")
+	if err == nil {
+		t.Fatalf("\nhave: <no error>\nwant: non-nil error")
+	}
+	have := err.Error()
+	needle := "group 'banana' does not exist"
+	if !strings.Contains(have, needle) {
+		t.Errorf("\nerror message:    %s\ndoes not contain: %s", have, needle)
+	}
 }
 
-func TestUserSystemAddSuccessVM(t *testing.T) {
+func TestUserSystemAddSuccess(t *testing.T) {
 	florist.SkipIfNotDisposableHost(t)
 
 	err := florist.UserSystemAdd("maniglia", "/opt/maniglia")
-
-	assert.NoError(t, err, "florist.UserSystemAdd")
+	if err != nil {
+		t.Errorf("\nhave error: %s\nwant: <no error>", err)
+	}
 }


### PR DESCRIPTION
This is an evolution of PR #5.

Uniform, future-proof API extensible with `opts` struct.

- Change signature `UserAdd(username string) error` -> `UserAdd(username string, opts UserAddOpts) error`
- Delete `SupplementaryGroups(username string, groups ...string) error`
- Delete `UserSystemAdd(username string, homedir string) error`
- Add `UserMod(username string, opts UserModOpts) error`
- Delete `GroupSystemAdd(groupname string) error`
- Add `GroupAdd(groupname string, opts GroupAddOpts) error`

TODO

- [ ] merge, tag v0.6.1
- [ ] 